### PR TITLE
Fix/enum arguments

### DIFF
--- a/templates/_mub.py
+++ b/templates/_mub.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from flask import request, send_from_directory, redirect
-from flask_fullstack import counter_parser, Undefined
+from flask_fullstack import counter_parser, Undefined, RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 
 from common import User, ResponseDoc
 from moderation import MUBController, permission_index

--- a/templates/_rst.py
+++ b/templates/_rst.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from flask import request, send_from_directory, redirect
-from flask_fullstack import counter_parser, Undefined
+from flask_fullstack import counter_parser, Undefined, RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 
 from common import User, ResourceController, ResponseDoc
 

--- a/xieffect/communities/base/__init__.py
+++ b/xieffect/communities/base/__init__.py
@@ -1,6 +1,6 @@
-from .meta_db import Community, Participant, ParticipantRole
 from .invitations_rst import controller as invitation_namespace
 from .invitations_sio import controller as invitation_events
+from .meta_db import Community, Participant, ParticipantRole
 from .meta_rst import controller as communities_namespace
 from .meta_sio import controller as communities_meta_events
 from .users_ext_db import CommunitiesUser

--- a/xieffect/communities/base/invitations_sio.py
+++ b/xieffect/communities/base/invitations_sio.py
@@ -45,15 +45,11 @@ class InvitationsEventSpace(EventSpace):
         self,
         event: DuplexEvent,
         community: Community,
-        role: str,
+        role: ParticipantRole,
         limit: int | None,
         days: int | None,
     ):
-        enum_role: ParticipantRole = ParticipantRole.from_string(role)
-        if enum_role is None:  # TODO pragma: no coverage
-            controller.abort(400, f"Invalid role: {role}")
-
-        invitation = Invitation.create(community.id, enum_role, limit, days)
+        invitation = Invitation.create(community.id, role, limit, days)
         db.session.commit()
         event.emit_convert(invitation, self.room_name(community.id))
         return invitation

--- a/xieffect/communities/utils.py
+++ b/xieffect/communities/utils.py
@@ -4,8 +4,8 @@ from functools import wraps
 
 from flask_fullstack import ResourceController, EventController, get_or_pop
 
-from .base import ParticipantRole, Community, Participant
 from common import User
+from .base.meta_db import ParticipantRole, Community, Participant
 
 
 def check_participant(

--- a/xieffect/education/authorship/user_roles_rst.py
+++ b/xieffect/education/authorship/user_roles_rst.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from flask_fullstack import RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 
 from common import ResourceController, User
 from .user_roles_db import Author

--- a/xieffect/education/knowledge/interaction_rst.py
+++ b/xieffect/education/knowledge/interaction_rst.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from functools import wraps
 
 from flask import redirect
+from flask_fullstack import RequestParser
 from flask_restx import Resource, Model
 from flask_restx.fields import Integer
-from flask_restx.reqparse import RequestParser
 
 from common import ResourceController, ResponseDoc, User
 from .interaction_db import ModuleProgressSession, TestModuleSession, TestPointSession

--- a/xieffect/education/knowledge/pages_rst.py
+++ b/xieffect/education/knowledge/pages_rst.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from flask_fullstack import counter_parser
+from flask_fullstack import counter_parser, RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 
 from common import ResourceController, User
 from .pages_db import Page

--- a/xieffect/other/updater_rst.py
+++ b/xieffect/other/updater_rst.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from flask import current_app
+from flask_fullstack import RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 
 from common import ResourceController, open_file
 from .discorder import send_message as send_discord_message, WebhookURLs
@@ -73,7 +73,7 @@ class WebhookPassthrough(Resource):
     parser.add_argument(
         "webhook",
         required=True,
-        choices=WebhookURLs.get_all_field_names(),
+        type=WebhookURLs.as_input(),
     )
     parser.add_argument(
         "message",
@@ -81,12 +81,10 @@ class WebhookPassthrough(Resource):
     )
 
     @controller.argument_parser(parser)
-    def post(self, api_key: str, webhook: str, message: str):
+    def post(self, api_key: str, webhook: WebhookURLs, message: str):
         if api_key != current_app.config["API_KEY"]:
             return {"a": "Wrong API_KEY"}, 403
-        if (webhook_url := WebhookURLs.from_string(webhook)) is None:
-            return {"a": f"Unsupported webhook URL: '{webhook}'"}, 400
-        send_discord_message(webhook_url, message)
+        send_discord_message(webhook, message)
         return {"a": "Success"}
 
 

--- a/xieffect/requirements.txt
+++ b/xieffect/requirements.txt
@@ -1,4 +1,4 @@
-flask-fullstack==0.4.9
+flask-fullstack==0.4.10
 
 # Misc
 discord-webhook~=0.14.0

--- a/xieffect/test/users/profiles_test.py
+++ b/xieffect/test/users/profiles_test.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from json import load as load_json
-from pytest import mark
 
 from flask.testing import FlaskClient
 from flask_fullstack import check_code
+from pytest import mark
 
 from common import open_file
 

--- a/xieffect/test/users/settings_test.py
+++ b/xieffect/test/users/settings_test.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+
 from flask.testing import FlaskClient
 from flask_fullstack import check_code
 from pytest import mark
 
-from .feedback_test import assert_message
 from vault import File
-from ..vault_test import upload
 from wsgi import TEST_EMAIL, BASIC_PASS
+from .feedback_test import assert_message
+from ..vault_test import upload
 
 TEST_EMAIL2 = "2@user.user"
 
@@ -69,7 +70,7 @@ def test_user_avatar(client: FlaskClient):
     file = File.find_by_id(file_id)
     assert user.get("id") == file.uploader_id
 
-    data = ((200, True, file_id), (404, "File not found", file_id+1))
+    data = ((200, True, file_id), (404, "File not found", file_id + 1))
     for code, message, file in data:
         avatar = {"avatar-id": file}
         assert_message(client, "/users/me/avatar/", message, code, **avatar)

--- a/xieffect/users/emailer_mub.py
+++ b/xieffect/users/emailer_mub.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from flask_fullstack import RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 
 from common import User
 from moderation import MUBController, permission_index
@@ -28,7 +28,7 @@ class EmailQAResource(Resource):  # TODO pragma: no coverage (action)
     parser.add_argument(
         "type",
         dest="email_type",
-        choices=EmailType.get_all_field_names(),
+        type=EmailType.as_input(),
         required=True,
     )
 
@@ -41,12 +41,8 @@ class EmailQAResource(Resource):  # TODO pragma: no coverage (action)
         self,
         user_email: str | None,
         tester_email: str,
-        email_type: str,
+        email_type: EmailType,
     ) -> str:
-        email_type = EmailType.from_string(email_type)
-        if email_type is None:  # TODO pragma: no coverage (and others?)
-            controller.abort(400, "Unsupported type")
-
         if user_email is None:
             user_email = tester_email
         user = User.find_by_email_address(user_email)

--- a/xieffect/users/feedback_mub.py
+++ b/xieffect/users/feedback_mub.py
@@ -19,7 +19,7 @@ class FeedbackDumper(Resource):
     parser.add_argument(
         "type",
         dest="feedback_type",
-        choices=FeedbackType.get_all_field_names(),
+        type=FeedbackType.as_input(),
         required=False,
     )
 
@@ -31,10 +31,8 @@ class FeedbackDumper(Resource):
         start: int,
         finish: int,
         user_id: int | None,
-        feedback_type: str | None,
+        feedback_type: FeedbackType | None,
     ) -> list[Feedback]:
-        if feedback_type is not None:
-            feedback_type = FeedbackType.from_string(feedback_type)
         return Feedback.search_by_params(start, finish - start, user_id, feedback_type)
 
 

--- a/xieffect/users/feedback_rst.py
+++ b/xieffect/users/feedback_rst.py
@@ -4,9 +4,9 @@ from enum import Enum
 from functools import wraps
 from os import getenv
 
+from flask_fullstack import RequestParser
 from flask_restx import Resource
 from flask_restx.fields import String as StringField
-from flask_restx.reqparse import RequestParser
 from itsdangerous import URLSafeSerializer, BadSignature
 
 from common import User, ResourceController, ResponseDoc
@@ -42,7 +42,7 @@ class FeedbackSaver(Resource):
     parser.add_argument(
         "type",
         required=True,
-        choices=FeedbackType.get_all_field_names(),
+        type=FeedbackType.as_input(),
         dest="feedback_type",
     )
     parser.add_argument(
@@ -73,7 +73,7 @@ class FeedbackSaver(Resource):
     def post(
         self,
         user: User | None,
-        feedback_type: str,
+        feedback_type: FeedbackType,
         data: dict,
         files: list[int],
         code: str | None,
@@ -81,7 +81,6 @@ class FeedbackSaver(Resource):
         if len(files) > 10:  # TODO pragma: no coverage
             controller.abort(413, "Too much files")
 
-        feedback_type = FeedbackType.from_string(feedback_type)
         feedback_files = File.find_by_ids(files)
 
         if len(feedback_files) != len(files):

--- a/xieffect/users/feedback_rst.py
+++ b/xieffect/users/feedback_rst.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from enum import Enum
 from functools import wraps
 from os import getenv

--- a/xieffect/users/invites_mub.py
+++ b/xieffect/users/invites_mub.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from flask_fullstack import counter_parser
+from flask_fullstack import counter_parser, RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 
 from moderation import MUBController, permission_index
 from .invites_db import Invite

--- a/xieffect/users/profiles_rst.py
+++ b/xieffect/users/profiles_rst.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from flask_fullstack import counter_parser
+from flask_fullstack import counter_parser, RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 
 from common import ResourceController, User
 

--- a/xieffect/users/reglog_rst.py
+++ b/xieffect/users/reglog_rst.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from flask import current_app
-from flask_fullstack import password_parser
+from flask_fullstack import password_parser, RequestParser
 from flask_jwt_extended import get_jwt
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 from itsdangerous import BadSignature
 
 from common import BlockedToken, ResourceController, User

--- a/xieffect/users/reglog_rst.py
+++ b/xieffect/users/reglog_rst.py
@@ -15,6 +15,7 @@ from .invites_db import Invite
 controller = ResourceController("reglog", path="/")
 
 
+@controller.route("/main/")
 @controller.route("/home/")
 class UserHome(Resource):
     @controller.jwt_authorizer(User)

--- a/xieffect/users/settings_rst.py
+++ b/xieffect/users/settings_rst.py
@@ -4,10 +4,10 @@ from flask_fullstack import password_parser
 from flask_restx import Resource, inputs
 from flask_restx.reqparse import RequestParser
 
-from vault import File
 from common import ResourceController, User
-from other import create_email_confirmer, EmailType, send_code_email
 from communities.base.users_ext_db import CommunitiesUser
+from other import create_email_confirmer, EmailType, send_code_email
+from vault import File
 
 controller = ResourceController("settings", path="/users/me/")
 

--- a/xieffect/users/settings_rst.py
+++ b/xieffect/users/settings_rst.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from flask_fullstack import password_parser
+from flask_fullstack import password_parser, RequestParser
 from flask_restx import Resource, inputs
-from flask_restx.reqparse import RequestParser
 
 from common import ResourceController, User
 from communities.base.users_ext_db import CommunitiesUser

--- a/xieffect/users/users_mub.py
+++ b/xieffect/users/users_mub.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from flask_fullstack import password_parser, counter_parser, Undefined
+from flask_fullstack import password_parser, counter_parser, Undefined, RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 from itsdangerous import BadSignature
 
 from common import User, TEST_INVITE_ID

--- a/xieffect/vault/files_rst.py
+++ b/xieffect/vault/files_rst.py
@@ -4,8 +4,8 @@ from contextlib import suppress
 from os import remove
 
 from flask import send_from_directory
+from flask_fullstack import RequestParser
 from flask_restx import Resource
-from flask_restx.reqparse import RequestParser
 from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import NotFound
 


### PR DESCRIPTION
Теперь `TypeEnum` можно нормально использовать в параметре `type` метода `RequestParser.add_argument`, конвертация строки от фронтенда в объект типа этого enum-а пройдёт автоматически. Работает даже в комбирации с `action="append"`. Также TypeEnum теперь корректно считывается из колонок БД и производит правильную документацию

При работе тут понял, что нам нужна параметризация в тестах, поэтому завёл: https://xi.kaiten.ru/space/90440/card/8040333